### PR TITLE
For issue #162 Add different regex pattern to search for meta tags

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -669,3 +669,14 @@ http://www.example.org/index.php" />
             get_meta_refresh(body, baseurl, ignore_tags=()),
             (0.0, "http://example.org/foobar_required"),
         )
+
+    def test_redirections_in_different_ordering__in_meta_tag(self):
+        baseurl = 'http://localhost:8000'
+        url1 = '<html><head><meta http-equiv="refresh" content="0;url=dummy.html"></head></html>'
+        url2 = '<html><head><meta content="0;url=dummy.html" http-equiv="refresh"></head></html>'
+        self.assertEqual(
+            get_meta_refresh(url1, baseurl), (0.0, 'http://localhost:8000/dummy.html')
+        )
+        self.assertEqual(
+            get_meta_refresh(url2, baseurl), (0.0, 'http://localhost:8000/dummy.html')
+        )

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -25,22 +25,7 @@ _meta_refresh_re2 = re.compile(
     r'<meta\s[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)\shttp-equiv="refresh"',
     re.DOTALL | re.IGNORECASE,
 )
-# create patterns here...
-# re_first = re.compile(r'meta\s[^>]*')
-# re_second = re.compile(r'content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*')
-# re_third = re.compile(r'http-equiv[^>]*refresh[^>]*')
-# re_fourth = re.compile(r'url=\s*(?P<url>.*?)(?P=quote)')
 
-# create a list with them
-# regexes = [re_first, re_second, re_third, re_fourth]
-
-# create the combined one
-# pattern_combined = '|'.join(x.pattern for x in regexes)
-#
-# _meta_refresh_re2 = re.compile(
-#     pattern_combined,
-#     re.DOTALL | re.IGNORECASE,
-# )
 _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
@@ -360,7 +345,6 @@ def get_meta_refresh(
     utext = remove_comments(replace_entities(utext))
     m = _meta_refresh_re.search(utext) or _meta_refresh_re2.search(utext)
     if m:
-        m.group("int")
         interval = float(m.group("int"))
         url = safe_url_string(m.group("url").strip(" \"'"), encoding)
         url = urljoin(baseurl, url)

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -21,6 +21,26 @@ _meta_refresh_re = re.compile(
     r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)',
     re.DOTALL | re.IGNORECASE,
 )
+_meta_refresh_re2 = re.compile(
+    r'<meta\s[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)\shttp-equiv="refresh"',
+    re.DOTALL | re.IGNORECASE,
+)
+# create patterns here...
+# re_first = re.compile(r'meta\s[^>]*')
+# re_second = re.compile(r'content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*')
+# re_third = re.compile(r'http-equiv[^>]*refresh[^>]*')
+# re_fourth = re.compile(r'url=\s*(?P<url>.*?)(?P=quote)')
+
+# create a list with them
+# regexes = [re_first, re_second, re_third, re_fourth]
+
+# create the combined one
+# pattern_combined = '|'.join(x.pattern for x in regexes)
+#
+# _meta_refresh_re2 = re.compile(
+#     pattern_combined,
+#     re.DOTALL | re.IGNORECASE,
+# )
 _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
@@ -338,8 +358,9 @@ def get_meta_refresh(
         raise
     utext = remove_tags_with_content(utext, ignore_tags)
     utext = remove_comments(replace_entities(utext))
-    m = _meta_refresh_re.search(utext)
+    m = _meta_refresh_re.search(utext) or _meta_refresh_re2.search(utext)
     if m:
+        m.group("int")
         interval = float(m.group("int"))
         url = safe_url_string(m.group("url").strip(" \"'"), encoding)
         url = urljoin(baseurl, url)


### PR DESCRIPTION
Changes:

- Add a second regex pattern with different ordering in meta tags
- Test that redirection occurs when dtags are differently ordered